### PR TITLE
Upgrade to Stack 13.26

### DIFF
--- a/cardano-sl-x509.cabal
+++ b/cardano-sl-x509.cabal
@@ -35,8 +35,8 @@ library
                , filepath
                , hourglass
                -- The IPv6 constructor has changed in 1.5 but Stackage
-               -- lts 13.14 specifies ip 1.4.2.1.
-               , ip < 1.5
+               -- lts 13.14 through 13.26 specifies ip 1.4.2.1.
+               , ip == 1.4.*
                , universum
                , unordered-containers
                , x509

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-resolver: lts-13.16
-compiler: ghc-8.6.4
+resolver: lts-13.26
+compiler: ghc-8.6.5
 
 packages:
   - .


### PR DESCRIPTION
The change to the cabal file was need due to https://github.com/haskell/cabal/issues/6121 .